### PR TITLE
todos os testes RED

### DIFF
--- a/calculadora/__init__.py
+++ b/calculadora/__init__.py
@@ -6,14 +6,14 @@ Number = Union[int, float]
 class Analisador(object):
     @classmethod
     def eh_valida(cls, expressao: str) -> bool:
-        pass
+        return None
 
     @classmethod
     def tokenizar(cls, expressao: str) -> List[str]:
-        pass
+        return None
 
 
 class Avaliador(object):
     @classmethod
     def avaliar(cls, expressao: str) -> Number:
-        pass
+        return float('NaN')

--- a/tests/calculadora_test.py
+++ b/tests/calculadora_test.py
@@ -9,25 +9,25 @@ class AnalisadorTestCase(unittest.TestCase):
             Analisador.eh_valida(2)
     
     def test_caso_dois(self):
-        self.assertFalse(Analisador.eh_valida('23*'))
+        self.assertIs(False, Analisador.eh_valida('23*'))
     
     def test_caso_tres(self):
-        self.assertFalse(Analisador.eh_valida('2 + 3'))
+        self.assertIs(False, Analisador.eh_valida('2 + 3'))
     
     def test_caso_quatro(self):
-        self.assertFalse(Analisador.eh_valida('2 3 x'))
+        self.assertIs(False, Analisador.eh_valida('2 3 x'))
     
     def test_caso_cinco(self):
-        self.assertFalse(Analisador.eh_valida('2 3 4 +'))
+        self.assertIs(False, Analisador.eh_valida('2 3 4 +'))
     
     def test_caso_seis(self):
-        self.assertTrue(Analisador.eh_valida('2 3 +'))
+        self.assertIs(True, Analisador.eh_valida('2 3 +'))
     
     def test_caso_sete(self):
-        self.assertTrue(Analisador.eh_valida('3 2 5 + *'))
+        self.assertIs(True, Analisador.eh_valida('3 2 5 + *'))
     
     def test_caso_oito(self):
-        self.assertTrue(Analisador.eh_valida('3.1 1.1 +'))
+        self.assertIs(True, Analisador.eh_valida('3.1 1.1 +'))
         
     def test_caso_nove(self):
         with self.assertRaises(TypeError):
@@ -91,7 +91,7 @@ class AnalisadorTestCase(unittest.TestCase):
         self.assertEqual(21, Avaliador.avaliar('3 2 5 + *'))
 
     def test_caso_vinte_e_quatro(self):
-        self.assertEqual(4.2, Analisador.eh_valida('3.1 1.1 +'))
+        self.assertAlmostEqual(4.2, Avaliador.avaliar('3.1 1.1 +'), 7)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
O commit faz com que **todos** os testes fiquem vermelhos.

Foram corrigidos os seguintes problemas:
- o retorno padrão de alguns métodos é `falsy` para o python, fazendo com que alguns `assertFalse` façam os testes (`test_caso_dois`, `test_caso_tres`, `test_caso_quatro` e `test_caso_cinco`) passar;
- alguns testes continham erro de digitação (`test_caso_vinte_e_quatro`);
